### PR TITLE
remove unknown, probably old string from library "rtimu", add find_library RTIMULib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
+find_library(RTIMULib libRTIMULib.so)
+
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -81,7 +83,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
-  LIBRARIES rtimu
+#  LIBRARIES 
   CATKIN_DEPENDS sensor_msgs roscpp tf
 #  DEPENDS system_lib
 )


### PR DESCRIPTION
There is a string pointing to an unknown probably old library entry "rtimu"
It does not keep the package from compiling, but when you put it as dependency in catkin, it will try to find it and the build will fail!