### PR TITLE
Add missing dependency on angles package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   roscpp
   tf
+  angles
 )
 
 ## System dependencies are found with CMake's conventions
@@ -84,7 +85,7 @@ find_library(RTIMULib libRTIMULib.so)
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES 
-  CATKIN_DEPENDS sensor_msgs roscpp tf
+  CATKIN_DEPENDS sensor_msgs roscpp tf angles
 #  DEPENDS system_lib
 )
 

--- a/package.xml
+++ b/package.xml
@@ -43,9 +43,11 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>angles</build_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>angles</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Make explicit that the angles package is required. Useful on minimal ROS installations, for example on raspberry pi.
